### PR TITLE
don't clear store on shutdown

### DIFF
--- a/puppification-discord-bot/src/index.ts
+++ b/puppification-discord-bot/src/index.ts
@@ -132,8 +132,8 @@ async function main(): Promise<void> {
 
   setupShutdown(async () => {
     logger.info('Shutting down...');
-    store.clear();
-    exemptions.clear();
+    // Don't clear() on shutdown because it would delete the save. 
+    // Just need to exit to clear memory.
     client.destroy();
   });
 


### PR DESCRIPTION
For some reason the SIGINT/shutdown code isn't being run reliably, but this should fix the issue with save being cleared when it does occur.

Reliable shutdown still needs work.