### PR TITLE
Include allowed words in translation

### DIFF
--- a/puppifier/src/easterEggs.ts
+++ b/puppifier/src/easterEggs.ts
@@ -5,6 +5,7 @@ import type { PaletteMix } from './tone.js';
 export interface EasterEggContext {
   rng: Random;
   mix: PaletteMix;
+  matches?: string[] | null;
 }
 
 /**
@@ -20,16 +21,19 @@ export interface EasterEgg {
   id: string;
   /** String substring or RegExp matched against the normalized sentence. */
   match: string | RegExp;
-  kind: 'override' | 'tag';
+  kind: 'override' | 'tag' | 'replaceWord';
   /** Required when kind === 'override'. */
   render?: (ctx: EasterEggContext) => string;
   /** Required when kind === 'tag'. The translator interprets this. */
   tag?: 'earsPerk';
+  matches?: string[] | null;
+  grammar?: "default"| "action";
 }
 
 function pickOne<T>(items: readonly T[], rng: Random): T {
   return rng.pick(items);
 }
+
 
 /**
  * Ordered list of easter eggs. Earlier entries take precedence on first
@@ -45,6 +49,7 @@ export const EASTER_EGGS: EasterEgg[] = [
       const soft = pickOne(['mrrf', 'hrmm', 'mrrrf', 'snrrf'], rng);
       return `${soft} *licks your face*`;
     },
+    grammar: "action",
   },
   {
     id: 'sorry',
@@ -73,6 +78,7 @@ export const EASTER_EGGS: EasterEgg[] = [
     match: /\b(?:meow|mrow)\b/,
     kind: 'override',
     render: () => `*imitates a cat*`,
+    grammar: "action",
   },
   {
     id: 'walk-treat-ball-park',
@@ -82,24 +88,111 @@ export const EASTER_EGGS: EasterEgg[] = [
   },
   {
     id: 'aroo-literal',
-    match: /\barooo+\b/,
+    match: /\bar(oo+)\b/,
     kind: 'override',
-    render: () => `Arooooooo!`,
+    render: ({ matches }) => `Ar${matches?.[1] ?? 'oo'}!`,
   },
   {
     id: 'awoo-literal',
-    match: /\bawooo+\b/,
+    match: /\baw(oo+)\b/,
     kind: 'override',
-    render: () => `Awooooooo!`,
+    render: ({ matches }) => `Aw${matches?.[1] ?? 'oo'}!`,
   },
   {
     id: 'aroo-long-word',
-    match: /\b(?:[a-z]{15,})\b/,
+    match: /\b([a-z]{15,})\b/,
     kind: 'override',
-    render: ({ rng }) => {
+    render: ({ rng, matches }) => {
       const numOs = rng.int(5,25);
       const awoOrAro = pickOne(['w', 'r'], rng);
       return `A${awoOrAro}${'o'.repeat(numOs)}!`;
+    },
+  },
+
+  // Individual word replacements
+  {
+    id: 'love',
+    match: /^loves?$/, // Match start and end of string instead of word boundry
+    kind: 'replaceWord',
+    render: ({ rng, matches }) => {
+      return `*licks lovingly*`;
+    },
+    grammar: "action",
+  },
+  {
+    id: 'paw',
+    match: /^paws?$/,
+    kind: 'replaceWord',
+    render: ({ rng, matches }) => {
+      return `*holds out paw*`;
+    },
+    grammar: "action",
+  },
+  {
+    id: 'lick',
+    match: /^licks?$/,
+    kind: 'replaceWord',
+    render: ({ rng, matches }) => {
+      return `*licks*`;
+    },
+    grammar: "action",
+  },
+  {
+    id: 'wag',
+    match: /^wags?$/,
+    kind: 'replaceWord',
+    render: ({ rng, matches }) => {
+      return `*wags tail*`;
+    },
+    grammar: "action",
+  },
+  {
+    id: 'nuzzle',
+    match: /^(nuzzles?)|(nose)$/,
+    kind: 'replaceWord',
+    render: ({ rng, matches }) => {
+      return `*nuzzle*`;
+    },
+    grammar: "action",
+  },
+  {
+    id: 'emoji-replacement-happy',
+    match: /^(:3)|(:\))|(🙂)|😃$/,
+    kind: 'replaceWord',
+    render: ({ rng, matches }) => {
+      return rng.pick(["૮・ᴥ・ა", "🐶", "૮ฅ・ﻌ・აฅ", "🐕", "૮₍ • ᴥ • ₎ა"]);
+    },
+  },
+  {
+    id: 'emoji-replacement-excited',
+    match: /^(\^_\^)|😄$/,
+    kind: 'replaceWord',
+    render: ({ rng, matches }) => {
+      return rng.pick(["૮ ˆﻌˆ ა", "🐶", "૮ฅ ˆﻌˆ აฅ"]);
+    },
+  },
+  {
+    id: 'emoji-replacement-love',
+    match: /^🥰|(<3)|😘|❤$/,
+    kind: 'replaceWord',
+    render: ({ rng, matches }) => {
+      return rng.pick(["♡૮ฅ ˆﻌˆ აฅ"]);
+    },
+  },
+  {
+    id: 'emoji-replacement-sleepy',
+    match: /^😴$/,
+    kind: 'replaceWord',
+    render: ({ rng, matches }) => {
+      return rng.pick(["zᶻ ૮˶- ﻌ -˶ა⌒)ᦱ"]);
+    },
+  },
+  {
+    id: 'emoji-replacement-shock',
+    match: /^😮$/,
+    kind: 'replaceWord',
+    render: ({ rng, matches }) => {
+      return rng.pick(["૮₍ ˶°ㅁ° ₎ა !!"]);
     },
   },
 ];
@@ -120,7 +213,26 @@ export function findOverride(sentence: string): EasterEgg | undefined {
   const norm = normalize(sentence);
   for (const egg of EASTER_EGGS) {
     if (egg.kind !== 'override') continue;
-    if (testMatch(egg.match, norm)) return egg;
+    if (testMatch(egg.match, norm)) {
+      if (typeof egg.match !== 'string') {
+        egg.matches = egg.match.exec(norm);
+      }
+      return egg;
+    }
+  }
+  return undefined;
+}
+
+export function findWordReplacement(word: string): EasterEgg | undefined {
+  const norm = normalize(word);
+  for (const egg of EASTER_EGGS) {
+    if (egg.kind !== 'replaceWord') continue;
+    if (testMatch(egg.match, norm)) {
+      if (typeof egg.match !== 'string') {
+        egg.matches = egg.match.exec(norm);
+      }
+      return egg;
+    }
   }
   return undefined;
 }

--- a/puppifier/src/easterEggs.ts
+++ b/puppifier/src/easterEggs.ts
@@ -22,7 +22,7 @@ export interface EasterEgg {
   /** String substring or RegExp matched against the normalized sentence. */
   match: string | RegExp;
   kind: 'override' | 'tag' | 'replaceWord';
-  /** Required when kind === 'override'. */
+  /** Required when kind === 'override' || 'replaceWord'. */
   render?: (ctx: EasterEggContext) => string;
   /** Required when kind === 'tag'. The translator interprets this. */
   tag?: 'earsPerk';
@@ -82,7 +82,7 @@ export const EASTER_EGGS: EasterEgg[] = [
   },
   {
     id: 'walk-treat-ball-park',
-    match: /\b(?:walk|walkies|treat|treats|ball|park|fetch)\b/,
+    match: /\b(?:walk|walkies|treat|treats|ball|park|fetch|bone)\b/,
     kind: 'tag',
     tag: 'earsPerk',
   },
@@ -102,10 +102,26 @@ export const EASTER_EGGS: EasterEgg[] = [
     id: 'aroo-long-word',
     match: /\b([a-z]{15,})\b/,
     kind: 'override',
-    render: ({ rng, matches }) => {
+    render: ({ rng }) => {
       const numOs = rng.int(5,25);
       const awoOrAro = pickOne(['w', 'r'], rng);
       return `A${awoOrAro}${'o'.repeat(numOs)}!`;
+    },
+  },
+  {
+    id: 'replace-discord-gif-links',
+    match: /^(https?:\/\/media\d.giphy.com\/media\/(.*)\.[a-z34]{2,4})|(https:\/\/.*tenor.com\/.*(\.[a-z34]{2,4})|[0-9]+)|(https:\/\/klipy.com\/gifs\/.*)$/,
+    kind: 'override',
+    render: ({ rng }) => {
+      return rng.pick([
+        "https://tenor.com/view/cute-puppy-aegi-golden-retriever-puppy-puppy-doggy-gif-6211630482704833346",
+        "https://tenor.com/view/crystal-amaru-gif-3146029766144478049",
+        "https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExZHE4MnlxcTV2bGx4dzFsNHhhOTJnaTI3MmJmMW41bTRxbXl3N3VjdiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/WQ2IwyAgYlmU0/giphy.gif",
+        "https://klipy.com/gifs/perrete",
+        "https://klipy.com/gifs/h2di-puppy-play",
+        "https://klipy.com/gifs/dog-smile-23",
+        "https://klipy.com/gifs/cute-dog-happy",
+      ]);
     },
   },
 
@@ -114,7 +130,7 @@ export const EASTER_EGGS: EasterEgg[] = [
     id: 'love',
     match: /^loves?$/, // Match start and end of string instead of word boundry
     kind: 'replaceWord',
-    render: ({ rng, matches }) => {
+    render: () => {
       return `*licks lovingly*`;
     },
     grammar: "action",
@@ -123,7 +139,7 @@ export const EASTER_EGGS: EasterEgg[] = [
     id: 'paw',
     match: /^paws?$/,
     kind: 'replaceWord',
-    render: ({ rng, matches }) => {
+    render: () => {
       return `*holds out paw*`;
     },
     grammar: "action",
@@ -141,7 +157,7 @@ export const EASTER_EGGS: EasterEgg[] = [
     id: 'wag',
     match: /^wags?$/,
     kind: 'replaceWord',
-    render: ({ rng, matches }) => {
+    render: () => {
       return `*wags tail*`;
     },
     grammar: "action",
@@ -150,7 +166,7 @@ export const EASTER_EGGS: EasterEgg[] = [
     id: 'nuzzle',
     match: /^(nuzzles?)|(nose)$/,
     kind: 'replaceWord',
-    render: ({ rng, matches }) => {
+    render: () => {
       return `*nuzzle*`;
     },
     grammar: "action",
@@ -176,7 +192,7 @@ export const EASTER_EGGS: EasterEgg[] = [
     match: /^🥰|(<3)|😘|❤$/,
     kind: 'replaceWord',
     render: ({ rng, matches }) => {
-      return rng.pick(["♡૮ฅ ˆﻌˆ აฅ"]);
+      return rng.pick(["❤૮ฅ ˆﻌˆ აฅ❤", "❤U(ᵔᴥᵔ)U"]);
     },
   },
   {
@@ -189,10 +205,49 @@ export const EASTER_EGGS: EasterEgg[] = [
   },
   {
     id: 'emoji-replacement-shock',
-    match: /^😮$/,
+    match: /^😮|(:o)$/,
     kind: 'replaceWord',
     render: ({ rng, matches }) => {
       return rng.pick(["૮₍ ˶°ㅁ° ₎ა !!"]);
+    },
+  },
+  {
+    id: 'emoji-replacement-v-v',
+    match: /^(v_v)|(v\.v)|😔$/,
+    kind: 'replaceWord',
+    render: ({ rng, matches }) => {
+      return rng.pick(["૮ ˘ﻌ˘ ა"]);
+    },
+  },
+  {
+    id: 'emoji-replacement-sad',
+    match: /^(😟|(:\()|(🙁))$/,
+    kind: 'replaceWord',
+    render: ({ rng, matches }) => {
+      return rng.pick(["૮ ◞ ﻌ ◟ ა", "U´꓃`U"]);
+    },
+  },
+  {
+    id: 'emoji-replacement-cry',
+    match: /^(😢|😭)$/,
+    kind: 'replaceWord',
+    render: ({ rng, matches }) => {
+      return rng.pick(["૮ ಥ ﻌ ಥ ა", "U〒ﻌ〒U"]);
+    },
+  },
+  {
+    id: 'randomize-links',
+    match: /^(?:http[s]?:\/\/.)?(?:www\.)?[-a-zA-Z0-9@%._\+~#=]{2,256}\.[a-z]{2,6}\b(?:[-a-zA-Z0-9@:%_\+.~#?&\/\/=]*)$/,
+    kind: 'replaceWord',
+    render: ({ rng, matches }) => {
+      return rng.pick([
+        "https://www.thesprucepets.com/",
+        "https://www.puppies.com/",
+        "https://www.puppyfinder.com/",
+        "https://unsplash.com/s/photos/puppy-wallpaper",
+        "https://www.allthingsdogs.com/dog-memes/",
+        "https://www.dogster.com/",
+      ]);
     },
   },
 ];

--- a/puppifier/src/grammar.ts
+++ b/puppifier/src/grammar.ts
@@ -56,6 +56,8 @@ export const DEFAULT_ACTION_SHAPE: ActionShapeOptions = {
 /**
  * List of plain puppy words to pass through, regexes are below.
  * For replacement and advanced usage see EasterEggs.
+ * Words are typically skipped/out of order so only sounds 
+ * without a part of speech are recommended.
  */
 export const puppyWords: Set<string|RegExp> = new Set([
   "arf",

--- a/puppifier/src/grammar.ts
+++ b/puppifier/src/grammar.ts
@@ -53,6 +53,35 @@ export const DEFAULT_ACTION_SHAPE: ActionShapeOptions = {
   includeModifiers: true,
 };
 
+/**
+ * List of plain puppy words to pass through, regexes will be handled elsewhere.
+ */
+export const puppyWords: Set<string> = new Set([
+  "arf",
+  "bau",
+  "baubau",
+  "borf",
+  "bowow",
+  "bowwow",
+  "rawr",
+  "sniff",
+  "yip",
+  "yap",
+  "🐶",
+  "🐕",
+  "🐩",
+]);
+
+export const puppyWordsRegex: RegExp[] = [
+  /^aro+$/,
+  /^awo+$/,
+  /^a(wa)+$/,
+  /^ar+u*f+$/,
+  /^a?woo+f$/,
+  /^grr+$/,
+  /^<\@\d{3,20}>$/, // preserve pings
+];
+
 const transitiveCommon: WeightedItem<string>[] = [
   { value: 'scratches', weight: 3 },
   { value: 'sniffs', weight: 3 },

--- a/puppifier/src/grammar.ts
+++ b/puppifier/src/grammar.ts
@@ -54,9 +54,10 @@ export const DEFAULT_ACTION_SHAPE: ActionShapeOptions = {
 };
 
 /**
- * List of plain puppy words to pass through, regexes will be handled elsewhere.
+ * List of plain puppy words to pass through, regexes are below.
+ * For replacement and advanced usage see EasterEggs.
  */
-export const puppyWords: Set<string> = new Set([
+export const puppyWords: Set<string|RegExp> = new Set([
   "arf",
   "bau",
   "baubau",
@@ -64,15 +65,13 @@ export const puppyWords: Set<string> = new Set([
   "bowow",
   "bowwow",
   "rawr",
+  "ruff",
   "sniff",
   "yip",
   "yap",
   "🐶",
   "🐕",
   "🐩",
-]);
-
-export const puppyWordsRegex: RegExp[] = [
   /^aro+$/,
   /^awo+$/,
   /^a(wa)+$/,
@@ -80,7 +79,15 @@ export const puppyWordsRegex: RegExp[] = [
   /^a?woo+f$/,
   /^grr+$/,
   /^<\@\d{3,20}>$/, // preserve pings
-];
+]);
+
+export const puppyWordsString = new Set(Array.from(puppyWords.values()).filter(
+  (w) => typeof w === "string"
+));
+
+export const puppyWordsRegex = Array.from(puppyWords.values()).filter(
+  (w) => w instanceof RegExp
+);
 
 const transitiveCommon: WeightedItem<string>[] = [
   { value: 'scratches', weight: 3 },

--- a/puppifier/src/templates.ts
+++ b/puppifier/src/templates.ts
@@ -1,6 +1,6 @@
 import type { Random } from './random.js';
 
-export type Slot = 'sound' | 'action' | 'opener' | 'closer';
+export type Slot = 'sound' | 'action' | 'opener' | 'closer' | 'allowedInput';
 
 export interface Template {
   slots: Slot[];
@@ -15,11 +15,11 @@ export interface Template {
  */
 export const TEMPLATES: Template[] = [
   { slots: ['sound'], weight: 3 },
-  { slots: ['sound', 'action'], weight: 4 },
-  { slots: ['opener', 'sound'], weight: 1 },
-  { slots: ['sound', 'action', 'sound'], weight: 2, minIntensity: 0.5 },
-  { slots: ['action', 'sound'], weight: 1 },
-  { slots: ['sound', 'closer'], weight: 1, minIntensity: 0.3 },
+  { slots: ['sound', 'action',  'allowedInput'], weight: 4 },
+  { slots: ['opener', 'allowedInput', 'sound'], weight: 1 },
+  { slots: ['sound', 'action', 'allowedInput', 'sound'], weight: 2, minIntensity: 0.5 },
+  { slots: ['action', 'allowedInput', 'sound'], weight: 1 },
+  { slots: ['sound', 'allowedInput', 'closer'], weight: 1, minIntensity: 0.3 },
 ];
 
 /**

--- a/puppifier/src/translator.ts
+++ b/puppifier/src/translator.ts
@@ -1,6 +1,6 @@
 import type { ToneScore } from 'emotion-classifier';
-import { findOverride, findTags } from './easterEggs.js';
-import { blendActionProbability, composeAction } from './grammar.js';
+import { EasterEgg, findOverride, findTags, findWordReplacement } from './easterEggs.js';
+import { blendActionProbability, composeAction, puppyWords, puppyWordsRegex } from './grammar.js';
 import { morph } from './morphology.js';
 import type { Palette, SoundEntry } from './palettes.js';
 import type { Profile } from './profile.js';
@@ -33,9 +33,23 @@ export function makeRecentBuffers(profile: Profile): TranslateBuffers {
   };
 }
 
-function countWords(s: string): number {
-  const m = s.trim().match(/\S+/g);
-  return m ? m.length : 0;
+function isAllowedWord(word: string): boolean {
+  let testWord = word.toLowerCase();
+  if (puppyWords.has(testWord)) {
+    return true;
+  }
+  for (let r of puppyWordsRegex) {
+    if (r.test(testWord)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function getWords(s: string): string[] | null {
+  const m = s.trim().match(/(\S+)/g);
+  return m;
 }
 
 function endsWithEllipsis(s: string): boolean {
@@ -208,7 +222,7 @@ export function translateSentence(
 
   const override = findOverride(trimmed);
   if (override?.render) {
-    return override.render({ rng: ctx.rng, mix }) + (addNewLine ? '\n' : '');
+    return override.render({ rng: ctx.rng, mix, matches: override.matches }) + (addNewLine ? '\n' : '');
   }
 
   const tags = findTags(trimmed);
@@ -217,7 +231,9 @@ export function translateSentence(
   const template = pickTemplate(mix.intensity, ctx.rng, ctx.profile.templates);
   const density = ctx.profile.density;
 
-  const wordCount = countWords(trimmed);
+  const wordArray = getWords(trimmed);
+  if (!wordArray) { return ""; }
+  const wordCount = wordArray?.length;
   const expectedSounds = Math.max(
     1,
     wordCount * density.soundsPerWord + (mix.intensity > 0 ? 0 : 0),
@@ -257,59 +273,89 @@ export function translateSentence(
   let actionsEmitted = 0;
   const parts: string[] = [];
 
-  for (const slot of template.slots) {
-    switch (slot satisfies Slot) {
-      case 'sound': {
-        const size = clusterSizes[soundIdx++] ?? 1;
-        const { cluster } = generateSoundCluster(size, mix, ctx, 'sounds');
-        parts.push(cluster);
-        break;
-      }
-      case 'opener': {
-        if (
-          actionSlotsInTemplate > 0 &&
-          actionsEmitted < targetActions &&
-          tryEmitAction()
-        ) {
-          const action = composeAction(
-            mix,
-            ctx.rng,
-            { verbs: ctx.buffers.verbs, verbObjects: ctx.buffers.verbObjects },
-            ctx.profile.grammars,
-            ctx.profile.actionShape,
-          );
-          parts.push(action);
-          actionsEmitted++;
-        } else {
-          // No action slot, exhausted, or gated out: open with an
-          // interjection sound so the sentence still has shape.
-          const { cluster } = generateSoundCluster(1, mix, ctx, 'interjections');
-          parts.push(cluster);
-        }
-        break;
-      }
-      case 'action':
-      case 'closer': {
-        if (actionsEmitted < targetActions && tryEmitAction()) {
-          const action = composeAction(
-            mix,
-            ctx.rng,
-            { verbs: ctx.buffers.verbs, verbObjects: ctx.buffers.verbObjects },
-            ctx.profile.grammars,
-            ctx.profile.actionShape,
-          );
-          parts.push(action);
-          actionsEmitted++;
-        }
-        break;
-      }
+  // for (const slot of template.slots) {
+  //   switch (slot satisfies Slot) {
+  //     case 'sound': {
+  //       const size = clusterSizes[soundIdx++] ?? 1;
+  //       const { cluster } = generateSoundCluster(size, mix, ctx, 'sounds');
+  //       parts.push(cluster);
+  //       break;
+  //     }
+  //     case 'opener': {
+  //       if (
+  //         actionSlotsInTemplate > 0 &&
+  //         actionsEmitted < targetActions &&
+  //         tryEmitAction()
+  //       ) {
+  //         const action = composeAction(
+  //           mix,
+  //           ctx.rng,
+  //           { verbs: ctx.buffers.verbs, verbObjects: ctx.buffers.verbObjects },
+  //           ctx.profile.grammars,
+  //           ctx.profile.actionShape,
+  //         );
+  //         parts.push(action);
+  //         actionsEmitted++;
+  //       } else {
+  //         // No action slot, exhausted, or gated out: open with an
+  //         // interjection sound so the sentence still has shape.
+  //         const { cluster } = generateSoundCluster(1, mix, ctx, 'interjections');
+  //         parts.push(cluster);
+  //       }
+  //       break;
+  //     }
+  //     case 'action':
+  //     case 'closer': {
+  //       if (actionsEmitted < targetActions && tryEmitAction()) {
+  //         const action = composeAction(
+  //           mix,
+  //           ctx.rng,
+  //           { verbs: ctx.buffers.verbs, verbObjects: ctx.buffers.verbObjects },
+  //           ctx.profile.grammars,
+  //           ctx.profile.actionShape,
+  //         );
+  //         parts.push(action);
+  //         actionsEmitted++;
+  //       }
+  //       break;
+  //     }
+  //   }
+  // }
+
+  for (let word of wordArray) {
+    let wordReplace: EasterEgg | undefined = undefined;
+    if (isAllowedWord(word)) {
+      parts.push(word);
+
+      // Additional
+      let count = ctx.rng.pickWeighted([0,1,2], [10,8,1]);
+      const { cluster } = generateSoundCluster(count, mix, ctx, ctx.rng.pick(['interjections', 'sounds']));
+      parts.push(cluster);
+    }
+    else if (
+      (wordReplace = findWordReplacement(word)) 
+      && wordReplace?.render
+    ) {
+      parts.push(wordReplace.render({ rng: ctx.rng, mix, matches: wordReplace.matches }));
+    }
+    else {
+      let count = ctx.rng.pickWeighted([0,1,2], [1,3,2]);
+      const { cluster } = generateSoundCluster(count, mix, ctx, ctx.rng.pick(['interjections', 'sounds']));
+      parts.push(cluster);
     }
   }
 
-  // Soft easter-egg tag: prepend an ears-perk opener if the template
-  // didn't already place an action at the front.
-  if (wantsEarsPerk && !hasOpenerAction(parts)) {
-    parts.unshift('*ears perk up*');
+  // closer 
+  if (actionsEmitted < targetActions && tryEmitAction()) {
+    const action = composeAction(
+      mix,
+      ctx.rng,
+      { verbs: ctx.buffers.verbs, verbObjects: ctx.buffers.verbObjects },
+      ctx.profile.grammars,
+      ctx.profile.actionShape,
+    );
+    parts.push(action);
+    actionsEmitted++;
   }
 
   // Optionally force all `*...*` action phrases to trail the sounds.
@@ -324,6 +370,22 @@ export function translateSentence(
     parts.length = 0;
     parts.push(...sounds, ...actions);
   }
+
+  // Soft easter-egg tag: prepend an ears-perk opener if the template
+  // didn't already place an action at the front.
+  if (wantsEarsPerk && !hasOpenerAction(parts)) {
+    parts.unshift('*ears perk up*');
+  }
+
+  // Separate sequential actions with a comma
+  parts.forEach((part, idx) => {
+    if (idx >= parts.length - 1) {
+      return;
+    }
+    if (part.startsWith("*") && parts[idx+1]?.startsWith("*")) {
+      parts[idx] = parts[idx] + ",";
+    }
+  });
 
   // Punctuation + caps preservation from the source sentence.
   const punct = trailingPunctuation(trimmed);

--- a/puppifier/src/translator.ts
+++ b/puppifier/src/translator.ts
@@ -227,12 +227,19 @@ export function translateSentence(
   tone: readonly ToneScore[],
   ctx: TranslateContext,
 ): string {
-  const trimmed = sentence.trim();
+  let trimmed = sentence.trim();
   if (trimmed.length === 0) return '';
 
   let addNewLine = false;
   if (sentence.charAt(sentence.length-1) === "\n") {
     addNewLine = true;
+  }
+
+  // Hard cap length at 1000 chars, prevent going over discord max and 
+  // prevent long processing times. Preserving long messages isn't of much 
+  // benefit.
+  if (trimmed.length > 1000) {
+    trimmed = trimmed.substring(0, 1000);
   }
 
   const mix = blendTones(tone);

--- a/puppifier/src/translator.ts
+++ b/puppifier/src/translator.ts
@@ -1,6 +1,6 @@
 import type { ToneScore } from 'emotion-classifier';
 import { EasterEgg, findOverride, findTags, findWordReplacement } from './easterEggs.js';
-import { blendActionProbability, composeAction, puppyWords, puppyWordsRegex } from './grammar.js';
+import { blendActionProbability, composeAction, puppyWordsString, puppyWordsRegex } from './grammar.js';
 import { morph } from './morphology.js';
 import type { Palette, SoundEntry } from './palettes.js';
 import type { Profile } from './profile.js';
@@ -35,7 +35,7 @@ export function makeRecentBuffers(profile: Profile): TranslateBuffers {
 
 function isAllowedWord(word: string): boolean {
   let testWord = word.toLowerCase();
-  if (puppyWords.has(testWord)) {
+  if (puppyWordsString.has(testWord)) {
     return true;
   }
   for (let r of puppyWordsRegex) {
@@ -201,6 +201,23 @@ function hasOpenerAction(parts: string[]): boolean {
   return parts.length > 0 && parts[0]!.startsWith('*');
 }
 
+function getAllowedWordCount(wordArray: string[]): number {
+  let returnCount = 0;
+  for (let word of wordArray) {
+    let wordReplace: EasterEgg | undefined = undefined;
+    if (isAllowedWord(word)) {
+      returnCount++;
+    }
+    else if (
+      (wordReplace = findWordReplacement(word)) 
+      && wordReplace?.render
+    ) {
+      returnCount++;
+    }
+  }
+  return returnCount;
+}
+
 /**
  * Translate a single sentence into a dog-speech string. See the plan's
  * "translator algorithm" section for the full step-by-step.
@@ -236,7 +253,7 @@ export function translateSentence(
   const wordCount = wordArray?.length;
   const expectedSounds = Math.max(
     1,
-    wordCount * density.soundsPerWord + (mix.intensity > 0 ? 0 : 0),
+    (wordCount - getAllowedWordCount(wordArray)) * density.soundsPerWord + (mix.intensity > 0 ? 0 : 0),
   );
   const totalSounds = jittered(
     expectedSounds,
@@ -272,90 +289,90 @@ export function translateSentence(
   let soundIdx = 0;
   let actionsEmitted = 0;
   const parts: string[] = [];
+  let allowedInputEmitted = false;
 
-  // for (const slot of template.slots) {
-  //   switch (slot satisfies Slot) {
-  //     case 'sound': {
-  //       const size = clusterSizes[soundIdx++] ?? 1;
-  //       const { cluster } = generateSoundCluster(size, mix, ctx, 'sounds');
-  //       parts.push(cluster);
-  //       break;
-  //     }
-  //     case 'opener': {
-  //       if (
-  //         actionSlotsInTemplate > 0 &&
-  //         actionsEmitted < targetActions &&
-  //         tryEmitAction()
-  //       ) {
-  //         const action = composeAction(
-  //           mix,
-  //           ctx.rng,
-  //           { verbs: ctx.buffers.verbs, verbObjects: ctx.buffers.verbObjects },
-  //           ctx.profile.grammars,
-  //           ctx.profile.actionShape,
-  //         );
-  //         parts.push(action);
-  //         actionsEmitted++;
-  //       } else {
-  //         // No action slot, exhausted, or gated out: open with an
-  //         // interjection sound so the sentence still has shape.
-  //         const { cluster } = generateSoundCluster(1, mix, ctx, 'interjections');
-  //         parts.push(cluster);
-  //       }
-  //       break;
-  //     }
-  //     case 'action':
-  //     case 'closer': {
-  //       if (actionsEmitted < targetActions && tryEmitAction()) {
-  //         const action = composeAction(
-  //           mix,
-  //           ctx.rng,
-  //           { verbs: ctx.buffers.verbs, verbObjects: ctx.buffers.verbObjects },
-  //           ctx.profile.grammars,
-  //           ctx.profile.actionShape,
-  //         );
-  //         parts.push(action);
-  //         actionsEmitted++;
-  //       }
-  //       break;
-  //     }
-  //   }
-  // }
-
-  for (let word of wordArray) {
-    let wordReplace: EasterEgg | undefined = undefined;
-    if (isAllowedWord(word)) {
-      parts.push(word);
-
-      // Additional
-      let count = ctx.rng.pickWeighted([0,1,2], [10,8,1]);
-      const { cluster } = generateSoundCluster(count, mix, ctx, ctx.rng.pick(['interjections', 'sounds']));
-      parts.push(cluster);
+  /**
+   * Side effect: increments actions emitted for every action easter egg. 
+   * @param wordArray input separated into words
+   * @returns array of parts for sentence from allowed and replaced words
+   */
+  function getAllowedWords(wordArray: string[]): string[] {
+    let returnParts = [];
+    for (let word of wordArray) {
+      let wordReplace: EasterEgg | undefined = undefined;
+      if (isAllowedWord(word)) {
+        returnParts.push(word);
+      }
+      else if (
+        (wordReplace = findWordReplacement(word)) 
+        && wordReplace?.render
+      ) {
+        returnParts.push(wordReplace.render({ rng: ctx.rng, mix, matches: wordReplace.matches }));
+        if (wordReplace.grammar === "action") {
+          actionsEmitted++;
+        }
+      }
     }
-    else if (
-      (wordReplace = findWordReplacement(word)) 
-      && wordReplace?.render
-    ) {
-      parts.push(wordReplace.render({ rng: ctx.rng, mix, matches: wordReplace.matches }));
-    }
-    else {
-      let count = ctx.rng.pickWeighted([0,1,2], [1,3,2]);
-      const { cluster } = generateSoundCluster(count, mix, ctx, ctx.rng.pick(['interjections', 'sounds']));
-      parts.push(cluster);
+    return returnParts;
+  }
+
+  for (const slot of template.slots) {
+    switch (slot satisfies Slot) {
+      case 'sound': {
+        const size = clusterSizes[soundIdx++] ?? 1;
+        const { cluster } = generateSoundCluster(size, mix, ctx, 'sounds');
+        parts.push(cluster);
+        break;
+      }
+      case 'allowedInput':
+        parts.push(... getAllowedWords(wordArray));
+        allowedInputEmitted = true;
+        break;
+      case 'opener': {
+        if (
+          actionSlotsInTemplate > 0 &&
+          actionsEmitted < targetActions &&
+          tryEmitAction()
+        ) {
+          const action = composeAction(
+            mix,
+            ctx.rng,
+            { verbs: ctx.buffers.verbs, verbObjects: ctx.buffers.verbObjects },
+            ctx.profile.grammars,
+            ctx.profile.actionShape,
+          );
+          parts.push(action);
+          actionsEmitted++;
+        } else {
+          // No action slot, exhausted, or gated out: open with an
+          // interjection sound so the sentence still has shape.
+          const { cluster } = generateSoundCluster(1, mix, ctx, 'interjections');
+          parts.push(cluster);
+        }
+        break;
+      }
+      case 'action':
+      case 'closer': {
+        if (actionsEmitted < targetActions && tryEmitAction()) {
+          const action = composeAction(
+            mix,
+            ctx.rng,
+            { verbs: ctx.buffers.verbs, verbObjects: ctx.buffers.verbObjects },
+            ctx.profile.grammars,
+            ctx.profile.actionShape,
+          );
+          parts.push(action);
+          actionsEmitted++;
+        }
+        break;
+      }
     }
   }
 
-  // closer 
-  if (actionsEmitted < targetActions && tryEmitAction()) {
-    const action = composeAction(
-      mix,
-      ctx.rng,
-      { verbs: ctx.buffers.verbs, verbObjects: ctx.buffers.verbObjects },
-      ctx.profile.grammars,
-      ctx.profile.actionShape,
-    );
-    parts.push(action);
-    actionsEmitted++;
+  // Append allowed parts to the end if not included in template
+  if (!allowedInputEmitted) {
+    parts.push(... getAllowedWords(wordArray));
+    allowedInputEmitted = true;
   }
 
   // Optionally force all `*...*` action phrases to trail the sounds.

--- a/puppifier/tests/easterEggs.test.ts
+++ b/puppifier/tests/easterEggs.test.ts
@@ -11,9 +11,20 @@ describe('easter eggs', () => {
     for (const egg of EASTER_EGGS) {
       if (egg.kind === 'override') {
         expect(typeof egg.render).to.equal('function');
-      } else {
-        expect(egg.kind).to.equal('tag');
+      } 
+      else if (egg.kind == "tag") {
         expect(egg.tag).to.be.a('string');
+      }
+      else if (egg.kind == "replaceWord") {
+        expect(typeof egg.render).to.equal('function');
+        expect(typeof egg.render).to.equal('function');
+      }
+      else {
+        expect(egg.kind).to.be.a("string");
+      }
+      if (egg.grammar && egg.grammar === "action") {
+        // render should include ** but need a context to test with
+        expect(typeof egg.render).to.equal('function');
       }
     }
   });

--- a/puppifier/tests/translator.test.ts
+++ b/puppifier/tests/translator.test.ts
@@ -205,7 +205,7 @@ describe('translateSentence', () => {
         buffers: makeRecentBuffers(profile),
       };
       const out = translateSentence('Hello there.', happyTone, ctx);
-      const tokens = out.match(/\*[^*]+\*|[^\s*]+/g) ?? [];
+      const tokens = out.match(/\*[^*]+\*|[^\s*,]+/g) ?? [];
       let seenAction = false;
       for (const tok of tokens) {
         if (tok.startsWith('*')) {


### PR DESCRIPTION
Translation refactoring to enable word preservation from allowlist.

Adds slot to templates that includes user input which is either:
- On allowlist
- On word level easter egg list

Also:
- Adds new easter eggs for gifs, urls, and words.
- Separates sequential actions by comma for readability

Resolves #1 
Affects (resolves?) #2 